### PR TITLE
Added bika_plone_extra_parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,22 @@ This role depends on the following Ansible Roles:
 - [Postfix](https://galaxy.ansible.com/tersmitten/postfix)
 
 
+## Examples
+
+To add worker zeo client, in configure.ymli add:
+
+bika_plone_extra_parts:
+    worker: |
+        <= client_base
+        recipe = plone.recipe.zope2instance
+        http-address = 127.0.0.1:{{ '%s' % (bika_plone_client_base_port|int + bika_plone_client_count|int + 1) }}
+
+To add zeo client caching, in configure.ymli add:
+
+bika_plone_client_extras: |
+    zeo-client-client = ${:_buildout_section_name_}
+
+
 ## Troubleshooting
 
 Problem:

--- a/roles/bika_plone/defaults/main.yml
+++ b/roles/bika_plone/defaults/main.yml
@@ -27,9 +27,11 @@ bika_plone_zeo_ip: 127.0.0.1
 bika_plone_zeo_port: 8100
 bika_plone_client_base_port: 8081
 bika_plone_zodb_cache_size: 30000
+bika_plone_extra_parts:
 bika_plone_buildout_extra:
 bika_plone_buildout_extra_parts:
 bika_plone_sources:
+bika_plone_environment_vars:
 
 # Supervisor Daemon HTTP
 bika_supervisor_with_http: no
@@ -92,6 +94,8 @@ bika_plone_config:
     plone_zeo_port: "{{ bika_plone_zeo_port }}"
     plone_client_base_port: "{{ bika_plone_client_base_port }}"
     plone_zodb_cache_size: "{{ bika_plone_zodb_cache_size }}"
+    plone_extra_parts: "{{ bika_plone_extra_parts }}"
     plone_buildout_extra: "{{ bika_plone_buildout_extra }}"
     plone_buildout_extra_parts: "{{ bika_plone_buildout_extra_parts }}"
     plone_sources: "{{ bika_plone_sources }}"
+    plone_environment_vars: "{{ bika_plone_environment_vars }}"


### PR DESCRIPTION
Added the linkage from bika_plone_extra_parts to plone_extra_parts to allow the adding of extra buildout parts. For example, 

bika_plone_extra_parts:
    worker: |
        <= client_base
        recipe = plone.recipe.zope2instance
        http-address = 127.0.0.1:{{ '%s' % (bika_plone_client_base_port|int + bika_plone_client_count|int + 1) }}
